### PR TITLE
BDRE-65 Enforcing Jira tkt in commit msg

### DIFF
--- a/bdre-scripts/local/bin/commit-msg
+++ b/bdre-scripts/local/bin/commit-msg
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# regex to validate in commit msg
+commit_regex='(BDRE-[0-9]+|merge)'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+error_msg="${RED}Commit not accepted:${NC} \nCommit message must have atleast one JIRA Issue (format 'BDRE-xxxx') or 'Merge'\ne.g. BDRE-1000 : Fixing the typo in variable name.\n"
+if ! grep -iqE "$commit_regex" "$1"; then
+    printf "$error_msg" >&2
+    exit 1
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,32 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <!-- here the phase you need -->
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/.git/hooks</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/bdre-scripts/local/bin</directory>
+                                    <includes>
+                                        <include>commit-msg</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <!-- To define the dependencies in your parent POM -->
@@ -618,5 +644,7 @@
     <!--<url>http://54.173.156.62:8081/nexus/content/repositories/snapshots</url>-->
     <!--</repository>-->
     <!--</repositories>-->
+
+
 
 </project>


### PR DESCRIPTION
@bdrekapil @sriharshaboda @mishisinku 

I'm adding a script to check the commit message for Jira ticket or 'merge' in the comments. This script gets installed in gits hook directory during first time build my maven. After that if the user does not add a Jira ticket number in the commit message git will reject the commit.

```
E:\bdre\bdre_app>git commit -am "enforcement of adding jira number in commit message"
Commit not accepted:
Commit message must have atleast one JIRA Issue (format 'BDRE-xxxx') or 'Merge'
e.g. BDRE-1000 : Fixing the typo in variable name.
```
