### PR TITLE
BDRE-104-- change the dq jar file from dq-$bdreVersion-jar-with-dependencies.jar to dq-$bdreVersion-executable.jar

### DIFF
--- a/bdre-scripts/remote/deployment/edgenode/process-type-19.sh
+++ b/bdre-scripts/remote/deployment/edgenode/process-type-19.sh
@@ -54,7 +54,7 @@ fi
 
 
 #copy generated jar for data-import
-cp -f $BDRE_HOME/lib/dq/dq-$bdreVersion-jar-with-dependencies.jar $BDRE_APPS_HOME/$busDomainId/$processTypeId/$processId/lib
+cp -f $BDRE_HOME/lib/dq/dq-$bdreVersion-executable.jar $BDRE_APPS_HOME/$busDomainId/$processTypeId/$processId/lib
 if [ $? -eq 1 ]
 then exit 1
 fi


### PR DESCRIPTION
BDRE-104 
Change the name of dq jar file in remote/deployment/edegenode/process-type-19.sh
