### PR TITLE
Reverting sonar check in travis CI BDRE-69

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,8 @@ before_install:
     - #curl -X POST  -H "Content-Type:application/json" -d "{\"body\":\"BDRE Robot triggered an automatic build verification for $TRAVIS_BRANCH branch because of your change. I shall test it and comment again shortly. Do not celebrate just yet.\"}" https://$GITHUB_APP_USER:$GITHUB_APP_TOKEN@api.github.com/repos/WiproOpenSourcePractice/openbdre/commits/$TRAVIS_COMMIT/comments
 install: /bin/true
 script:
-    - mvn -s settings.xml clean install sonar:sonar -P hdp22 org.jacoco:jacoco-maven-plugin:prepare-agent -Dclirr=true -Dsonar.analysis.mode=preview -Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST -Dsonar.github.repository=wiproopensourcepractice/openbdre -Dsonar.github.oauth=$GITHUB_APP_TOKEN -Dsonar.host.url=$SONAR_URL -Dsonar.login=$SONAR_LOGIN -Dsonar.password=$SONAR_PASSWORD -pl '!im-crawler' --quiet
+    - mvn -s settings.xml clean install -P hdp22 -pl '!im-crawler' --quiet
+after_success:
+    - #curl -X POST  -H "Content-Type:application/json" -d "{\"body\":\"BDRE Robot confirms that the build from $TRAVIS_BRANCH passed. Build logs available at https://travis-ci.org/WiproOpenSourcePractice/openbdre/builds/$TRAVIS_BUILD_ID\"}" https://$GITHUB_APP_USER:$GITHUB_APP_TOKEN@api.github.com/repos/WiproOpenSourcePractice/openbdre/commits/$TRAVIS_COMMIT/comments
+after_failure:
+    - #curl -X POST  -H "Content-Type:application/json" -d "{\"body\":\"BDRE Robot says that it encountered an error while building $TRAVIS_BRANCH. Build logs available at https://travis-ci.org/WiproOpenSourcePractice/openbdre/builds/$TRAVIS_BUILD_ID\"}" https://$GITHUB_APP_USER:$GITHUB_APP_TOKEN@api.github.com/repos/WiproOpenSourcePractice/openbdre/commits/$TRAVIS_COMMIT/comments


### PR DESCRIPTION
Reverting sonar check in travis CI due to non support of secured variable during PR from fork
