### PR TITLE
BDRE-219: Instanceexec listing was giving erroneous result in UI

### DIFF
--- a/md-dao/src/main/java/com/wipro/ats/bdre/md/dao/InstanceExecDAO.java
+++ b/md-dao/src/main/java/com/wipro/ats/bdre/md/dao/InstanceExecDAO.java
@@ -54,10 +54,10 @@ public class InstanceExecDAO {
             if (processId == null) {
 
                 counter = session.createCriteria(InstanceExec.class).list().size();
-                Criteria joinBatchInstanceExec = session.createCriteria(Batch.class, "b").createAlias("b.instanceExec", "ieid", JoinType.RIGHT_OUTER_JOIN).addOrder(Order.desc("ieid.instanceExecId"));
+                Criteria joinBatchInstanceExec = session.createCriteria(InstanceExec.class).addOrder(Order.desc("instanceExecId"));
                 joinBatchInstanceExec.setFirstResult(pageNum);
                 joinBatchInstanceExec.setMaxResults(numResults);
-                batchList = joinBatchInstanceExec.list();
+                instanceExeces = joinBatchInstanceExec.list();
 
             } else {
                 counter = session.createCriteria(InstanceExec.class).add(Restrictions.eq("process.processId", processId)).list().size();


### PR DESCRIPTION
DAO's if condition was modified to fix this to select \* from INSTANCE_EXEC;
